### PR TITLE
Fix `.label-*` coloring bug (#1286)

### DIFF
--- a/_sass/labels.scss
+++ b/_sass/labels.scss
@@ -5,7 +5,7 @@
 // for more, see https://github.com/just-the-docs/just-the-docs/issues/1272
 // and the accompanying PR
 .label:not(g),
-.label-blue {
+.label-blue:not(g) {
   display: inline-block;
   padding: 0.16em 0.56em;
   margin-right: $sp-2;
@@ -19,19 +19,19 @@
   border-radius: 12px;
 }
 
-.label-green {
+.label-green:not(g) {
   background-color: $green-200;
 }
 
-.label-purple {
+.label-purple:not(g) {
   background-color: $purple-100;
 }
 
-.label-red {
+.label-red:not(g) {
   background-color: $red-200;
 }
 
-.label-yellow {
+.label-yellow:not(g) {
   color: $grey-dk-200;
   background-color: $yellow-200;
 }


### PR DESCRIPTION
Closes #1285.

(missed this in code review, which is also my bad! this is because the `:not` selector changes specificity, which in turn changes the cascade)